### PR TITLE
Refer to ExecutionFailedError via Interface::Admin

### DIFF
--- a/lib/kafkat/command/elect-leaders.rb
+++ b/lib/kafkat/command/elect-leaders.rb
@@ -22,7 +22,7 @@ module Kafkat
           print "\nBeginning.\n"
           result = admin.elect_leaders!(partitions)
           print "Started.\n"
-        rescue Admin::ExecutionFailedError
+        rescue Interface::Admin::ExecutionFailedError
           print result
         end
       end

--- a/lib/kafkat/command/reassign.rb
+++ b/lib/kafkat/command/reassign.rb
@@ -80,7 +80,7 @@ module Kafkat
           print "\nBeginning.\n"
           result = admin.reassign!(assignments)
           print "Started.\n"
-        rescue Admin::ExecutionFailedError
+        rescue Interface::Admin::ExecutionFailedError
           print result
         end
       end

--- a/lib/kafkat/command/shutdown.rb
+++ b/lib/kafkat/command/shutdown.rb
@@ -21,7 +21,7 @@ module Kafkat
           print "\nBeginning shutdown.\n"
           result = admin.shutdown!(broker_id)
           print "Started.\n"
-        rescue Admin::ExecutionFailedError
+        rescue Interface::Admin::ExecutionFailedError
           print result
         end
       end


### PR DESCRIPTION
Otherwise this fails as Admin::ExecutionFailedError resides in Kafkat::Interface instead of Kafkat::Command
