### PR TITLE
Added support for specifying partitions targeted for reassignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Here's a list of supported commands:
   partitions [topic]                                                  Print partitions by topic.
   partitions [topic] --under-replicated                               Print partitions by topic (only under-replicated).
   partitions [topic] --unavailable                                    Print partitions by topic (only unavailable).
-  reassign [topic] [--brokers <ids>] [--replicas <n>]                 Begin reassignment of partitions.
+  reassign [topic] [--brokers <ids>] [--partitions <ids>]             Begin reassignment of partitions.
+           [--replicas <n>]
   resign-rewrite <broker id>                                          Forcibly rewrite leaderships to exclude a broker.
   resign-rewrite <broker id> --force                                  Same as above but proceed if there are no available ISRs.
   set-replication-factor [topic] [--newrf <n>] [--brokers id[,id]]    Set the replication factor of

--- a/lib/kafkat/cluster/assignment.rb
+++ b/lib/kafkat/cluster/assignment.rb
@@ -1,4 +1,4 @@
 module Kafkat
-  class Assignment < Struct.new(:partition, :replicas)
+  class Assignment < Struct.new(:topic_name, :partition_id, :replicas)
   end
 end

--- a/lib/kafkat/cluster/assignment.rb
+++ b/lib/kafkat/cluster/assignment.rb
@@ -1,4 +1,4 @@
 module Kafkat
-  class Assignment < Struct.new(:topic_name, :partition_id, :replicas)
+  class Assignment < Struct.new(:partition, :replicas)
   end
 end

--- a/lib/kafkat/command/reassign.rb
+++ b/lib/kafkat/command/reassign.rb
@@ -80,7 +80,7 @@ module Kafkat
             end
 
             replicas.reverse!
-            assignments << Assignment.new(p, replicas)
+            assignments << Assignment.new(t.name, p.id, replicas)
           end
         end
 

--- a/lib/kafkat/command/reassign.rb
+++ b/lib/kafkat/command/reassign.rb
@@ -39,6 +39,15 @@ module Kafkat
 
         topics.each do |_, t|
           if opts[:partitions]
+            # we need to convert the array of Partitions to an array of
+            # ids in order to perform set operations
+            part_ids = t.partitions.map {|partition| partition.id}
+            invalid_partitions = opts[:partitions] - part_ids
+            unless invalid_partitions.empty?
+              print "ERROR: partition(s) #{invalid_partitions.inspect} do not exist.\n"
+              exit 1
+            end
+
             # apply filter on partitions by selecting only those partitions that have
             # been targeted based on the command line options
             partitions = t.partitions.select { |partition| opts[:partitions].include? partition.id }
@@ -71,7 +80,7 @@ module Kafkat
             end
 
             replicas.reverse!
-            assignments << Assignment.new(t.name, p.id, replicas)
+            assignments << Assignment.new(p, replicas)
           end
         end
 

--- a/lib/kafkat/command/reassign.rb
+++ b/lib/kafkat/command/reassign.rb
@@ -3,7 +3,7 @@ module Kafkat
     class Reassign < Base
       register_as 'reassign'
 
-      usage 'reassign [topic] [--brokers <ids>] [--replicas <n>]',
+      usage 'reassign [topic] [--brokers <ids>] [--partitions <ids>] [--replicas <n>]',
             'Begin reassignment of partitions.'
 
       def run
@@ -15,6 +15,7 @@ module Kafkat
 
         opts = Trollop.options do
           opt :brokers, "replica set (broker IDs)", type: :string
+          opt :partitions, "targeted partitions", type: :ints
           opt :replicas, "number of replicas (count)", type: :integer
         end
 
@@ -37,9 +38,17 @@ module Kafkat
         broker_count = broker_ids.size
 
         topics.each do |_, t|
+          if opts[:partitions]
+            # apply filter on partitions by selecting only those partitions that have
+            # been targeted based on the command line options
+            partitions = t.partitions.select { |partition| opts[:partitions].include? partition.id }
+          else
+            partitions = t.partitions
+          end
+
           # This is how Kafka's AdminUtils determines these values.
-          partition_count = t.partitions.size
-          topic_replica_count = replica_count || t.partitions[0].replicas.size
+          partition_count = partitions.size
+          topic_replica_count = replica_count || partitions[0].replicas.size
 
           if topic_replica_count > broker_count
             print "ERROR: Replication factor (#{topic_replica_count}) is larger than brokers (#{broker_count}).\n"
@@ -49,7 +58,7 @@ module Kafkat
           start_index = Random.rand(broker_count)
           replica_shift = Random.rand(broker_count)
 
-          t.partitions.each do |p|
+          partitions.each do |p|
             replica_shift += 1 if p.id > 0 && p.id % broker_count == 0
             first_replica_index = (p.id + start_index) % broker_count
 


### PR DESCRIPTION
Most of the time, we see that only specific partitions need reassignment, so when we used the existing reassign command for a topic, we found that we incurred unnecessary workload for Kafka to replicate all partitions for a topic.  With this change, we can trigger only targeted partitions to get reassigned by using the following command:

```
kafkat reassign my_topic -p 1 2 3
```

The above command will only cause reassignment for partitions 1, 2, and 3 for the topic <tt>my_topic</tt>.

One caveat is that this option may not be as effective if used with all topics, but I couldn't think of a simple way to achieve this through the cli.
