### PR TITLE
Reduce data movement when reassign patitions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    coderay (1.1.0)
     colored (1.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
@@ -29,8 +30,13 @@ GEM
     logging (1.8.2)
       little-plugger (>= 1.1.3)
       multi_json (>= 1.8.4)
+    method_source (0.8.2)
     minitest (5.7.0)
     multi_json (1.11.1)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rake (10.4.2)
     retryable (1.3.6)
     rspec (3.2.0)
@@ -53,6 +59,7 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
+    slop (3.6.0)
     thread_safe (0.3.5)
     trollop (2.1.2)
     tzinfo (1.2.2)
@@ -68,6 +75,7 @@ PLATFORMS
 DEPENDENCIES
   factory_girl (~> 4.5.0)
   kafkat!
+  pry
   rake
   rspec (~> 3.2.0)
   rspec-collection_matchers (~> 1.1.0)

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ Here's a list of supported commands:
   partitions [topic] --under-replicated                               Print partitions by topic (only under-replicated).
   partitions [topic] --unavailable                                    Print partitions by topic (only unavailable).
   reassign [topic] [--brokers <ids>] [--replicas <n>]                 Begin reassignment of partitions.
-           [--strategy smart|load-balanced]                           Default smart strategy minimizes data moved around,
-                                                                      load-balanced strategy randomly assign partitions.
+           [--strategy smart|load-balanced]                           
   resign-rewrite <broker id>                                          Forcibly rewrite leaderships to exclude a broker.
   resign-rewrite <broker id> --force                                  Same as above but proceed if there are no available ISRs.
   set-replication-factor [topic] [--newrf <n>] [--brokers id[,id]]    Set the replication factor of

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Here's a list of supported commands:
   partitions [topic] --under-replicated                               Print partitions by topic (only under-replicated).
   partitions [topic] --unavailable                                    Print partitions by topic (only unavailable).
   reassign [topic] [--brokers <ids>] [--replicas <n>]                 Begin reassignment of partitions.
+           [--strategy smart|load-balanced]                           Default smart strategy minimizes data moved around,
+                                                                      load-balanced strategy randomly assign partitions.
   resign-rewrite <broker id>                                          Forcibly rewrite leaderships to exclude a broker.
   resign-rewrite <broker id> --force                                  Same as above but proceed if there are no available ISRs.
   set-replication-factor [topic] [--newrf <n>] [--brokers id[,id]]    Set the replication factor of

--- a/kafkat.gemspec
+++ b/kafkat.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'colored', '~> 1.2'
 
   s.add_development_dependency 'rake'
+  s.add_development_dependency 'pry'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'rspec', '~> 3.2.0'
   s.add_development_dependency 'rspec-collection_matchers', '~> 1.1.0'

--- a/lib/kafkat/cli.rb
+++ b/lib/kafkat/cli.rb
@@ -44,7 +44,7 @@ module Kafkat
       Command.all.values.sort_by(&:command_name).each do |klass|
         klass.usages.each do |usage|
           format, description = usage[0], usage[1]
-          padding_length = 68 - format.length
+          padding_length = 70 - format.length
           padding = " " * padding_length unless padding_length < 0
           print "  #{format}#{padding}#{description}\n"
         end

--- a/lib/kafkat/command/drain.rb
+++ b/lib/kafkat/command/drain.rb
@@ -75,18 +75,6 @@ module Kafkat
 
         assignments
       end
-
-      # Build a hash map from broker_id to number of partitions on it to facilitate
-      # finding the broker with lowest number of partitions to help balance brokers.
-      def build_num_partitions_on_broker_map(topic, all_broker_ids)
-        num_partitions_on_broker = Hash[all_broker_ids.collect { |id| [id, 0] }]
-        topic.partitions.each do |p|
-          p.replicas.each do |r|
-            num_partitions_on_broker[r] += 1
-          end
-        end
-        num_partitions_on_broker
-      end
     end
   end
 end

--- a/lib/kafkat/command/reassign.rb
+++ b/lib/kafkat/command/reassign.rb
@@ -63,20 +63,20 @@ module Kafkat
           end
 
           assignments += assignment_strategy.generate_topic_assignment(
-            topic, topic_replica_count, destination_broker_ids, all_broker_ids, broker_count)
+            topic, topic_replica_count, destination_broker_ids)
         end
 
         prompt_and_execute_assignments(assignments)
       end
-    end
 
-    # This is how Kafka's AdminUtils determines these values.
-    def get_topic_replica_count(topic)
-      if topic.partitions.empty?
-        print "ERROR: Topic \"#{topic.name}\" has no partition.\n"
-        exit 1
+      # This is how Kafka's AdminUtils determines these values.
+      def get_topic_replica_count(topic)
+        if topic.partitions.empty?
+          print "ERROR: Topic \"#{topic.name}\" has no partition.\n"
+          exit 1
+        end
+        topic.partitions[0].replicas.size
       end
-      topic.partitions[0].replicas.size
     end
 
     class AssignmentStrategy

--- a/lib/kafkat/command/reassign.rb
+++ b/lib/kafkat/command/reassign.rb
@@ -3,8 +3,9 @@ module Kafkat
     class Reassign < Base
       register_as 'reassign'
 
-      usage 'reassign [topic] [--brokers <ids>] [--replicas <n>]',
-            'Begin reassignment of partitions.'
+      usage 'reassign [topic] [--brokers <ids>] [--replicas <n>] [--strategy smart|load-balanced]',
+            'Begin reassignment of partitions.\n'\
+            'Default smart strategy minimizes data moved around, load-balanced strategy randomly assign partitions.'
 
       def run
         topic_name = ARGV.shift unless ARGV[0] && ARGV[0].start_with?('--')
@@ -16,33 +17,139 @@ module Kafkat
         opts = Trollop.options do
           opt :brokers, "replica set (broker IDs)", type: :string
           opt :replicas, "number of replicas (count)", type: :integer
+          opt :strategy, "assignment strategy used", type: :string
         end
 
-        broker_ids = opts[:brokers] && opts[:brokers].split(',').map(&:to_i)
+        destination_broker_ids = opts[:brokers] && opts[:brokers].split(',').map(&:to_i)
         replica_count = opts[:replicas]
+        strategy = opts[:strategy]
+        strategy ||= "smart"
 
-        broker_ids ||= zookeeper.get_brokers.values.map(&:id)
+        destination_broker_ids ||= zookeeper.get_brokers.values.map(&:id)
 
-        all_brokers_id = all_brokers.values.map(&:id)
-        broker_ids.each do |id|
-          if !all_brokers_id.include?(id)
+        all_broker_ids = all_brokers.values.map(&:id)
+        destination_broker_ids.each do |id|
+          if !all_broker_ids.include? id
             print "ERROR: Broker #{id} is not currently active.\n"
             exit 1
           end
         end
 
-        # *** This logic is duplicated from Kakfa 0.8.1.1 ***
+        if strategy == "smart"
+          assignments = generate_assignment_smart(topics, destination_broker_ids,
+                                                  replica_count, all_broker_ids)
+        elsif strategy == "load-balanced"
+          assignments = generate_assignment_load_balanced(topics, destination_broker_ids,
+                                                          replica_count)
+        else
+          print "ERROR: Unrecognized strategy \"#{strategy}\".\n"
+          exit 1
+        end
 
+        prompt_and_execute_assignments(assignments)
+      end
+
+      # This is the default assignment generation strategy.
+      # There are two requirements:
+      #   1. replicas should be evenly distributed among brokers;
+      #   2. replicas moving around should be avoided as possible.
+      # We also need to address that user can sepcify both number of brokers and
+      # replication factors.
+      #
+      # To address the requirements efficiently, two passes are used to determine assignemnt.
+      # In the first pass, existing assignments where partitions with too many replicas (probably
+      # due to decrese of replication factor) and brokers with too many replicas (probably due to
+      # decrease of replication factor or increase of number of brokers) are removed.
+      # Brokers not in destination brokers are also removed from assignment in the first pass.
+      #
+      # In the second pass, partitions are assigned with available brokers if neither the partition
+      # nor the brokers are full. Assignemnts where brokers are full are swaped with availble
+      # brokers.
+      #
+      # To facilitate the two passes, two hash tables are maintained to keep track of quota
+      # on each broker and assigned partitions on each broker.
+      def generate_assignment_smart(topics, destination_broker_ids, replica_count, all_broker_ids)
+        broker_count = destination_broker_ids.size
         assignments = []
-        broker_count = broker_ids.size
 
         topics.each do |_, t|
-          # This is how Kafka's AdminUtils determines these values.
           partition_count = t.partitions.size
-          topic_replica_count = replica_count || t.partitions[0].replicas.size
+          topic_replica_count = get_topic_replica_count(t, replica_count)
 
           if topic_replica_count > broker_count
-            print "ERROR: Replication factor (#{topic_replica_count}) is larger than brokers (#{broker_count}).\n"
+            print "ERROR: Replication factor (#{topic_replica_count}) "\
+                  "is larger than brokers (#{broker_count}).\n"
+            exit 1
+          end
+
+          num_partitions_on_broker = build_num_partitions_on_broker_map(t, all_broker_ids)
+          partitions_quota_on_broker =
+            generate_partitions_quota_on_broker(partition_count, topic_replica_count,
+                                                destination_broker_ids, num_partitions_on_broker)
+
+
+
+          # First pass: remove assignment where both broker and partition exceed quota,
+          # or brokers not in destination brokers.
+          t.partitions.each do |p|
+            p.replicas.delete_if do |broker|
+              if (p.replicas.size > topic_replica_count &&
+                  num_partitions_on_broker[broker] > partitions_quota_on_broker[broker]) ||
+                 !destination_broker_ids.include?(broker)
+
+                num_partitions_on_broker[broker] -= 1
+                true
+              end
+            end
+          end
+
+          # Second pass
+          t.partitions.each do |p|
+            # find brokers not assigned with the partition and not meet quota
+            available_brokers = destination_broker_ids - p.replicas
+            available_brokers.delete_if do |broker|
+              num_partitions_on_broker[broker] >= partitions_quota_on_broker[broker]
+            end
+
+            # remove broker exceeding quota if available brokers exit
+            p.replicas.delete_if do |broker|
+              if p.replicas.size + available_brokers.size > topic_replica_count &&
+                num_partitions_on_broker[broker] > partitions_quota_on_broker[broker]
+
+                num_partitions_on_broker[broker] -= 1
+                true
+              end
+            end
+
+            # fill empty replicas or remove extra replicas
+            while p.replicas.size < topic_replica_count
+              assigned_broker = available_brokers.shift
+              num_partitions_on_broker[assigned_broker] += 1
+              p.replicas << assigned_broker
+            end
+            while p.replicas.size > topic_replica_count
+              removed_broker = p.replicas.shift
+              num_partitions_on_broker[removed_broker] -= 1
+            end
+
+            assignments << Assignment.new(t.name, p.id, p.replicas)
+          end
+        end
+
+        assignments
+      end
+
+      # *** This logic is duplicated from Kakfa 0.8.1.1 ***
+      def generate_assignment_load_balanced(topics, destination_broker_ids, replica_count)
+        broker_count = destination_broker_ids.size
+        assignments = []
+
+        topics.each do |_, t|
+          topic_replica_count = get_topic_replica_count(t, replica_count)
+
+          if topic_replica_count > broker_count
+            print "ERROR: Replication factor (#{topic_replica_count}) "\
+                  "is larger than brokers (#{broker_count}).\n"
             exit 1
           end
 
@@ -53,12 +160,12 @@ module Kafkat
             replica_shift += 1 if p.id > 0 && p.id % broker_count == 0
             first_replica_index = (p.id + start_index) % broker_count
 
-            replicas = [broker_ids[first_replica_index]]
+            replicas = [destination_broker_ids[first_replica_index]]
 
             (0...topic_replica_count-1).each do |i|
               shift = 1 + (replica_shift + i) % (broker_count - 1)
               index = (first_replica_index + shift) % broker_count
-              replicas << broker_ids[index]
+              replicas << destination_broker_ids[index]
             end
 
             replicas.reverse!
@@ -66,9 +173,39 @@ module Kafkat
           end
         end
 
-        # ****************
+        assignments
+      end
 
-        prompt_and_execute_assignments(assignments)
+      # This is how Kafka's AdminUtils determines these values.
+      def get_topic_replica_count(topic, replica_count)
+        if topic.partitions.empty?
+          print "ERROR: Topic \"#{topic.name}\" has no partition.\n"
+          exit 1
+        end
+        replica_count || topic.partitions[0].replicas.size
+      end
+
+      # Assign quota to brokers.
+      # Quota is evenly distributed among detination brokers where as those destination brokers
+      # with more replicas initially might be assigned with one more if quota cannot be
+      # distrbuted completely evenly.
+      def generate_partitions_quota_on_broker(partition_count, topic_replica_count,
+                                              destination_broker_ids, num_partitions_on_broker)
+        total_partitions = partition_count * topic_replica_count
+        min_replicas_per_broker = total_partitions / destination_broker_ids.size
+        remaining_replicas_quota = total_partitions % destination_broker_ids.size
+
+        partitions_quota_on_broker = Hash.new(0)
+        destination_broker_ids.each do |id|
+          partitions_quota_on_broker[id] = min_replicas_per_broker
+        end
+        num_partitions_on_broker.select { |id, _| destination_broker_ids.include? id }
+          .sort_by { |id, num| -num }.first(remaining_replicas_quota).each do |id, _|
+
+          partitions_quota_on_broker[id] += 1
+        end
+
+        partitions_quota_on_broker
       end
     end
   end

--- a/lib/kafkat/command/reassign.rb
+++ b/lib/kafkat/command/reassign.rb
@@ -36,161 +36,135 @@ module Kafkat
         end
 
         if strategy == "smart"
-          assignments = generate_assignment_smart(topics, destination_broker_ids,
-                                                  replica_count, all_broker_ids)
+          assignment_strategy = SmartStrategy.new()
         elsif strategy == "load-balanced"
-          assignments = generate_assignment_load_balanced(topics, destination_broker_ids,
-                                                          replica_count)
+          assignment_strategy = LoadBalancedStrategy.new()
         else
           print "ERROR: Unrecognized strategy \"#{strategy}\".\n"
           exit 1
         end
 
+        broker_count = destination_broker_ids.size
+        assignments = []
+
+        topics.each do |_, topic|
+          topic_replica_count = get_topic_replica_count(topic, replica_count)
+          if topic_replica_count > broker_count
+            print "ERROR: Replication factor (#{topic_replica_count}) "\
+                  "is larger than brokers (#{broker_count}).\n"
+            exit 1
+          end
+
+          assignments += assignment_strategy.generate_topic_assignment(
+            topic, topic_replica_count, destination_broker_ids, replica_count, all_broker_ids)
+        end
+
         prompt_and_execute_assignments(assignments)
       end
+    end
 
+    # This is how Kafka's AdminUtils determines these values.
+    def get_topic_replica_count(topic, replica_count)
+      if topic.partitions.empty?
+        print "ERROR: Topic \"#{topic.name}\" has no partition.\n"
+        exit 1
+      end
+      replica_count || topic.partitions[0].replicas.size
+    end
+
+    class AssignmentStrategy
+      def generate_topic_assignment(
+        topic, topic_replica_count, destination_broker_ids, all_broker_ids, broker_count)
+
+        raise NotImplementedError.new()
+      end
+    end
+
+    class LoadBalancedStrategy < AssignmentStrategy
+      # *** This logic is duplicated from Kakfa 0.8.1.1 ***
+      def generate_topic_assignment(
+        topic, topic_replica_count, destination_broker_ids, _, broker_count)
+
+        assignment = []
+        start_index = Random.rand(broker_count)
+        replica_shift = Random.rand(broker_count)
+
+        topic.partitions.each do |p|
+          replica_shift += 1 if p.id > 0 && p.id % broker_count == 0
+          first_replica_index = (p.id + start_index) % broker_count
+
+          replicas = [destination_broker_ids[first_replica_index]]
+
+          (0...topic_replica_count-1).each do |i|
+            shift = 1 + (replica_shift + i) % (broker_count - 1)
+            index = (first_replica_index + shift) % broker_count
+            replicas << destination_broker_ids[index]
+          end
+
+          replicas.reverse!
+          assignment << Assignment.new(topic.name, p.id, replicas)
+        end
+
+        assignment
+      end
+    end
+
+    class SmartStrategy < AssignmentStrategy
       # This is the default assignment generation strategy.
       # There are two requirements:
       #   1. replicas should be evenly distributed among brokers;
       #   2. replicas moving around should be avoided as possible.
       # We also need to address that user can sepcify both number of brokers and
       # replication factors.
-      #
-      # To address the requirements efficiently, two passes are used to determine assignemnt.
-      # In the first pass, existing assignments where partitions with too many replicas (probably
-      # due to decrese of replication factor) and brokers with too many replicas (probably due to
-      # decrease of replication factor or increase of number of brokers) are removed.
-      # Brokers not in destination brokers are also removed from assignment in the first pass.
-      #
-      # In the second pass, partitions are assigned with available brokers if neither the partition
-      # nor the brokers are full. Assignemnts where brokers are full are swaped with availble
-      # brokers.
-      #
-      # To facilitate the two passes, two hash tables are maintained to keep track of quota
-      # on each broker and assigned partitions on each broker.
-      def generate_assignment_smart(topics, destination_broker_ids, replica_count, all_broker_ids)
-        broker_count = destination_broker_ids.size
-        assignments = []
+      def generate_topic_assignment(
+        topic, topic_replica_count, destination_broker_ids, all_broker_ids, _)
 
-        topics.each do |_, t|
-          partition_count = t.partitions.size
-          topic_replica_count = get_topic_replica_count(t, replica_count)
+        assignment = []
 
-          if topic_replica_count > broker_count
-            print "ERROR: Replication factor (#{topic_replica_count}) "\
-                  "is larger than brokers (#{broker_count}).\n"
-            exit 1
-          end
+        partition_count = topic.partitions.size
+        num_partitions_on_broker = build_num_partitions_on_broker_map(topic, all_broker_ids)
+        partitions_quota_on_broker = generate_partitions_quota_on_broker(
+          partition_count, topic_replica_count, destination_broker_ids, num_partitions_on_broker)
 
-          num_partitions_on_broker = build_num_partitions_on_broker_map(t, all_broker_ids)
-          partitions_quota_on_broker =
-            generate_partitions_quota_on_broker(partition_count, topic_replica_count,
-                                                destination_broker_ids, num_partitions_on_broker)
+        remove_replicas_with_overfilled_broker_and_partition(
+          topic,
+          topic_replica_count,
+          num_partitions_on_broker,
+          partitions_quota_on_broker,
+          destination_broker_ids)
 
+        topic.partitions.each do |p|
+          available_brokers = find_available_brokers(
+            destination_broker_ids, p, num_partitions_on_broker, partitions_quota_on_broker)
 
+          remove_assignment_with_overfilled_broker(
+            p,
+            available_brokers,
+            topic_replica_count,
+            num_partitions_on_broker,
+            partitions_quota_on_broker)
 
-          # First pass: remove assignment where both broker and partition exceed quota,
-          # or brokers not in destination brokers.
-          t.partitions.each do |p|
-            p.replicas.delete_if do |broker|
-              if (p.replicas.size > topic_replica_count &&
-                  num_partitions_on_broker[broker] > partitions_quota_on_broker[broker]) ||
-                 !destination_broker_ids.include?(broker)
+          fill_underfilled_partition(
+            p, topic_replica_count, available_brokers, num_partitions_on_broker)
+          trim_overfilled_partition(p, topic_replica_count, num_partitions_on_broker)
 
-                num_partitions_on_broker[broker] -= 1
-                true
-              end
-            end
-          end
-
-          # Second pass
-          t.partitions.each do |p|
-            # find brokers not assigned with the partition and not meet quota
-            available_brokers = destination_broker_ids - p.replicas
-            available_brokers.delete_if do |broker|
-              num_partitions_on_broker[broker] >= partitions_quota_on_broker[broker]
-            end
-
-            # remove broker exceeding quota if available brokers exit
-            p.replicas.delete_if do |broker|
-              if p.replicas.size + available_brokers.size > topic_replica_count &&
-                num_partitions_on_broker[broker] > partitions_quota_on_broker[broker]
-
-                num_partitions_on_broker[broker] -= 1
-                true
-              end
-            end
-
-            # fill empty replicas or remove extra replicas
-            while p.replicas.size < topic_replica_count
-              assigned_broker = available_brokers.shift
-              num_partitions_on_broker[assigned_broker] += 1
-              p.replicas << assigned_broker
-            end
-            while p.replicas.size > topic_replica_count
-              removed_broker = p.replicas.shift
-              num_partitions_on_broker[removed_broker] -= 1
-            end
-
-            assignments << Assignment.new(t.name, p.id, p.replicas)
-          end
+          assignment << Assignment.new(topic.name, p.id, p.replicas)
         end
 
-        assignments
+        assignment
       end
 
-      # *** This logic is duplicated from Kakfa 0.8.1.1 ***
-      def generate_assignment_load_balanced(topics, destination_broker_ids, replica_count)
-        broker_count = destination_broker_ids.size
-        assignments = []
-
-        topics.each do |_, t|
-          topic_replica_count = get_topic_replica_count(t, replica_count)
-
-          if topic_replica_count > broker_count
-            print "ERROR: Replication factor (#{topic_replica_count}) "\
-                  "is larger than brokers (#{broker_count}).\n"
-            exit 1
-          end
-
-          start_index = Random.rand(broker_count)
-          replica_shift = Random.rand(broker_count)
-
-          t.partitions.each do |p|
-            replica_shift += 1 if p.id > 0 && p.id % broker_count == 0
-            first_replica_index = (p.id + start_index) % broker_count
-
-            replicas = [destination_broker_ids[first_replica_index]]
-
-            (0...topic_replica_count-1).each do |i|
-              shift = 1 + (replica_shift + i) % (broker_count - 1)
-              index = (first_replica_index + shift) % broker_count
-              replicas << destination_broker_ids[index]
-            end
-
-            replicas.reverse!
-            assignments << Assignment.new(t.name, p.id, replicas)
-          end
-        end
-
-        assignments
-      end
-
-      # This is how Kafka's AdminUtils determines these values.
-      def get_topic_replica_count(topic, replica_count)
-        if topic.partitions.empty?
-          print "ERROR: Topic \"#{topic.name}\" has no partition.\n"
-          exit 1
-        end
-        replica_count || topic.partitions[0].replicas.size
-      end
-
+    private
       # Assign quota to brokers.
       # Quota is evenly distributed among detination brokers where as those destination brokers
       # with more replicas initially might be assigned with one more if quota cannot be
       # distrbuted completely evenly.
-      def generate_partitions_quota_on_broker(partition_count, topic_replica_count,
-                                              destination_broker_ids, num_partitions_on_broker)
+      def generate_partitions_quota_on_broker(
+        partition_count,
+        topic_replica_count,
+        destination_broker_ids,
+        num_partitions_on_broker)
+
         total_partitions = partition_count * topic_replica_count
         min_replicas_per_broker = total_partitions / destination_broker_ids.size
         remaining_replicas_quota = total_partitions % destination_broker_ids.size
@@ -206,6 +180,78 @@ module Kafkat
         end
 
         partitions_quota_on_broker
+      end
+
+      # Existing assignments where partitions with too many replicas ( due to decrese of
+      # replication factor) and brokers with too many replicas (due to decrease of replication
+      # factor or increase of number of brokers) are removed.
+      # Brokers not in destination brokers are also removed.
+      def remove_replicas_with_overfilled_broker_and_partition(
+        topic,
+        topic_replica_count,
+        num_partitions_on_broker,
+        partitions_quota_on_broker,
+        destination_broker_ids)
+
+        topic.partitions.each do |p|
+          p.replicas.delete_if do |broker|
+            if (p.replicas.size > topic_replica_count &&
+                num_partitions_on_broker[broker] > partitions_quota_on_broker[broker]) ||
+               !destination_broker_ids.include?(broker)
+
+              num_partitions_on_broker[broker] -= 1
+              true
+            end
+          end
+        end
+      end
+
+      # Find brokers not assigned with the partition and not meet quota
+      def find_available_brokers(
+        destination_broker_ids, partition, num_partitions_on_broker, partitions_quota_on_broker)
+
+        available_brokers = destination_broker_ids - partition.replicas
+        available_brokers.delete_if do |broker|
+          num_partitions_on_broker[broker] >= partitions_quota_on_broker[broker]
+        end
+        available_brokers
+      end
+
+      # Remove broker exceeding quota if enough available brokers exit.
+      # If not enough brokers available while existing broker exceeding quota, this means the broker
+      # is overfilled with other partitions, and will meet quota in later iteration.
+      def remove_assignment_with_overfilled_broker(
+        partition,
+        available_brokers,
+        topic_replica_count,
+        num_partitions_on_broker,
+        partitions_quota_on_broker)
+
+        partition.replicas.delete_if do |broker|
+          if partition.replicas.size + available_brokers.size > topic_replica_count &&
+            num_partitions_on_broker[broker] > partitions_quota_on_broker[broker]
+
+            num_partitions_on_broker[broker] -= 1
+            true
+          end
+        end
+      end
+
+      def fill_underfilled_partition(
+        partition, topic_replica_count, available_brokers, num_partitions_on_broker)
+
+        while partition.replicas.size < topic_replica_count
+          assigned_broker = available_brokers.shift
+          num_partitions_on_broker[assigned_broker] += 1
+          partition.replicas << assigned_broker
+        end
+      end
+
+      def trim_overfilled_partition(partition, topic_replica_count, num_partitions_on_broker)
+        while partition.replicas.size > topic_replica_count
+          removed_broker = partition.replicas.shift
+          num_partitions_on_broker[removed_broker] -= 1
+        end
       end
     end
   end

--- a/lib/kafkat/command/reassign.rb
+++ b/lib/kafkat/command/reassign.rb
@@ -3,9 +3,10 @@ module Kafkat
     class Reassign < Base
       register_as 'reassign'
 
-      usage 'reassign [topic] [--brokers <ids>] [--replicas <n>] [--strategy smart|load-balanced]',
+      usage 'reassign [topic] [--brokers <ids>] [--strategy smart|load-balanced]',
             'Begin reassignment of partitions.\n'\
-            'Default smart strategy minimizes data moved around, load-balanced strategy randomly assign partitions.'
+            'Default smart strategy minimizes data moved around, '\
+            'load-balanced strategy randomly assign partitions.'
 
       def run
         topic_name = ARGV.shift unless ARGV[0] && ARGV[0].start_with?('--')
@@ -16,12 +17,18 @@ module Kafkat
 
         opts = Trollop.options do
           opt :brokers, "replica set (broker IDs)", type: :string
-          opt :replicas, "number of replicas (count)", type: :integer
+          opt :replicas, "NO longer support changing replication factor through this command",
+            type: :integer
           opt :strategy, "assignment strategy used", type: :string
         end
 
+        if opts[:replicas]
+          print "ERROR: No longer support changing replication factor through this command. "\
+                "Use `set-replication-factor` instead.\n"
+          exit 1
+        end
+
         destination_broker_ids = opts[:brokers] && opts[:brokers].split(',').map(&:to_i)
-        replica_count = opts[:replicas]
         strategy = opts[:strategy]
         strategy ||= "smart"
 
@@ -48,7 +55,7 @@ module Kafkat
         assignments = []
 
         topics.each do |_, topic|
-          topic_replica_count = get_topic_replica_count(topic, replica_count)
+          topic_replica_count = get_topic_replica_count(topic)
           if topic_replica_count > broker_count
             print "ERROR: Replication factor (#{topic_replica_count}) "\
                   "is larger than brokers (#{broker_count}).\n"
@@ -56,7 +63,7 @@ module Kafkat
           end
 
           assignments += assignment_strategy.generate_topic_assignment(
-            topic, topic_replica_count, destination_broker_ids, replica_count, all_broker_ids)
+            topic, topic_replica_count, destination_broker_ids, all_broker_ids, broker_count)
         end
 
         prompt_and_execute_assignments(assignments)
@@ -64,17 +71,16 @@ module Kafkat
     end
 
     # This is how Kafka's AdminUtils determines these values.
-    def get_topic_replica_count(topic, replica_count)
+    def get_topic_replica_count(topic)
       if topic.partitions.empty?
         print "ERROR: Topic \"#{topic.name}\" has no partition.\n"
         exit 1
       end
-      replica_count || topic.partitions[0].replicas.size
+      topic.partitions[0].replicas.size
     end
 
     class AssignmentStrategy
-      def generate_topic_assignment(
-        topic, topic_replica_count, destination_broker_ids, all_broker_ids, broker_count)
+      def generate_topic_assignment(topic, topic_replica_count, destination_broker_ids)
 
         raise NotImplementedError.new
       end
@@ -82,10 +88,10 @@ module Kafkat
 
     class LoadBalancedStrategy < AssignmentStrategy
       # *** This logic is duplicated from Kakfa 0.8.1.1 ***
-      def generate_topic_assignment(
-        topic, topic_replica_count, destination_broker_ids, _, broker_count)
+      def generate_topic_assignment(topic, topic_replica_count, destination_broker_ids)
 
         assignment = []
+        broker_count = destination_broker_ids.size
         start_index = Random.rand(broker_count)
         replica_shift = Random.rand(broker_count)
 
@@ -112,108 +118,61 @@ module Kafkat
     class SmartStrategy < AssignmentStrategy
       # This is the default assignment generation strategy.
       # There are two requirements:
-      #   1. replicas should be evenly distributed among brokers;
+      #   1. replicas should be as evenly distributed among brokers as possible;
       #   2. replicas moving around should be avoided as possible.
-      # We also need to address that user can sepcify both number of brokers and
-      # replication factors.
-      def generate_topic_assignment(
-        topic, topic_replica_count, destination_broker_ids, all_broker_ids, _)
+      def generate_topic_assignment(topic, topic_replica_count, destination_broker_ids)
+
+        remove_unused_brokers(topic, destination_broker_ids)
+        num_partitions_on_broker = build_num_partitions_on_broker_map(topic, destination_broker_ids)
+        remove_overfilled_brokers(
+          topic, topic_replica_count, destination_broker_ids, num_partitions_on_broker)
+        fill_underfilled_partitions(
+          topic, topic_replica_count, destination_broker_ids, num_partitions_on_broker)
 
         assignment = []
-
-        brokers_quota = generate_brokers_quota(
-          topic, topic_replica_count, destination_broker_ids, all_broker_ids)
-
-        remove_unused_brokers(topic, brokers_quota, destination_broker_ids)
-
         topic.partitions.each do |p|
-          available_brokers = find_available_brokers(destination_broker_ids, p, brokers_quota)
-          remove_overfilled_brokers(p, available_brokers, topic_replica_count, brokers_quota)
-          fill_underfilled_partition(p, topic_replica_count, available_brokers, brokers_quota)
-          trim_overfilled_partition(p, topic_replica_count, brokers_quota)
-
           assignment << Assignment.new(topic.name, p.id, p.replicas)
         end
-
         assignment
       end
 
     private
-      # Quota is the target number of partitions minus the current number of partitions on a broker.
-      def generate_brokers_quota(
-        topic, topic_replica_count, destination_broker_ids, all_broker_ids)
+      def remove_unused_brokers(topic, destination_broker_ids)
+        topic.partitions.each do |p|
+          p.replicas.delete_if { |broker| !destination_broker_ids.include?(broker) }
+        end
+      end
+
+      # Remove overfilled brokers from partitions with most replicas.
+      def remove_overfilled_brokers(
+        topic, topic_replica_count, destination_broker_ids, num_partitions_on_broker)
 
         partition_count = topic.partitions.size
         total_partitions = partition_count * topic_replica_count
         min_replicas_per_broker = total_partitions / destination_broker_ids.size
-        remaining_replicas_quota = total_partitions % destination_broker_ids.size
-        num_partitions_on_broker = build_num_partitions_on_broker_map(topic, all_broker_ids)
+        num_partitions_on_broker.select { |_, num| num > min_replicas_per_broker }.each do |id, _|
+          topic.partitions
+            .select { |p| p.replicas.include? id }
+            .sort_by { |p| -p.replicas.size }
+            .first(num_partitions_on_broker[id] - min_replicas_per_broker).each do |p|
 
-        brokers_quota = Hash.new(0)
-        destination_broker_ids.each { |id| brokers_quota[id] = min_replicas_per_broker }
-        # give remaining partitions to brokers with more replicas initially
-        num_partitions_on_broker.select { |id, _| destination_broker_ids.include? id }
-          .sort_by { |id, num| -num }.first(remaining_replicas_quota).each do |id, _|
-
-          brokers_quota[id] += 1
-        end
-
-        brokers_quota.each { |id, _| brokers_quota[id] -= num_partitions_on_broker[id] }
-        brokers_quota
-      end
-
-      # Remove assignments where brokers are not in destination brokers.
-      def remove_unused_brokers(topic, brokers_quota, destination_broker_ids)
-
-        topic.partitions.each do |p|
-          p.replicas.delete_if do |broker|
-            unless destination_broker_ids.include?(broker)
-
-              brokers_quota[broker] += 1
-              true
-            end
+            p.replicas.delete(id)
           end
+          num_partitions_on_broker[id] = min_replicas_per_broker
         end
       end
 
-      # Find brokers not assigned with the partition and not meet quota
-      def find_available_brokers(destination_broker_ids, partition, brokers_quota)
+      # Fill the partition with least number of replicas with brokers with least number partitions.
+      def fill_underfilled_partitions(
+        topic, topic_replica_count, destination_broker_ids, num_partitions_on_broker)
 
-        available_brokers = destination_broker_ids - partition.replicas
-        available_brokers.delete_if { |broker| brokers_quota[broker] <= 0 }
-        available_brokers
-      end
+        while p = topic.partitions.select { |p| p.replicas.size < topic_replica_count}
+          .sort_by { |p| p.replicas.size }.first
 
-      # Remove broker exceeding quota if enough available brokers exist.
-      # If not enough brokers available while existing broker exceeding quota, this means the broker
-      # is overfilled with other partitions, and will meet quota in later iteration.
-      def remove_overfilled_brokers(
-        partition, available_brokers, topic_replica_count, brokers_quota)
-
-        partition.replicas.delete_if do |broker|
-          if partition.replicas.size + available_brokers.size > topic_replica_count &&
-            brokers_quota[broker] < 0
-
-            brokers_quota[broker] += 1
-            true
-          end
-        end
-      end
-
-      def fill_underfilled_partition(
-        partition, topic_replica_count, available_brokers, brokers_quota)
-
-        while partition.replicas.size < topic_replica_count
-          assigned_broker = available_brokers.shift
-          brokers_quota[assigned_broker] -= 1
-          partition.replicas << assigned_broker
-        end
-      end
-
-      def trim_overfilled_partition(partition, topic_replica_count, brokers_quota)
-        while partition.replicas.size > topic_replica_count
-          removed_broker = partition.replicas.shift
-          brokers_quota[removed_broker] += 1
+          assigned_broker =
+            (destination_broker_ids - p.replicas).sort_by { |id| num_partitions_on_broker[id]}.first
+          p.replicas << assigned_broker
+          num_partitions_on_broker[assigned_broker] += 1
         end
       end
     end

--- a/lib/kafkat/command/reassign.rb
+++ b/lib/kafkat/command/reassign.rb
@@ -37,9 +37,9 @@ eof
 
         destination_broker_ids ||= zookeeper.get_brokers.values.map(&:id)
 
-        all_broker_ids = all_brokers.values.map(&:id)
+        all_active_broker_ids = all_brokers.values.map(&:id)
         destination_broker_ids.each do |id|
-          if !all_broker_ids.include? id
+          if !all_active_broker_ids.include? id
             print "ERROR: Broker #{id} is not currently active.\n"
             exit 1
           end

--- a/lib/kafkat/command/reassign.rb
+++ b/lib/kafkat/command/reassign.rb
@@ -4,9 +4,12 @@ module Kafkat
       register_as 'reassign'
 
       usage 'reassign [topic] [--brokers <ids>] [--strategy smart|load-balanced]',
-            'Begin reassignment of partitions.\n'\
-            'Default smart strategy minimizes data moved around, '\
-            'load-balanced strategy randomly assign partitions.'
+            <<eof
+Begin reassignment of partitions.
+Two assignment strategies are available:
+ - the Smart strategy (default) minimizes the number of partitions actually moved,
+ - the Load-Balanced strategy uniformly distributes the partitions over the specified brokers.
+eof
 
       def run
         topic_name = ARGV.shift unless ARGV[0] && ARGV[0].start_with?('--')

--- a/lib/kafkat/utility.rb
+++ b/lib/kafkat/utility.rb
@@ -1,2 +1,14 @@
 require 'kafkat/utility/formatting'
 require 'kafkat/utility/command_io'
+
+# Build a hash map from broker_id to number of partitions on it to facilitate
+# finding the broker with lowest number of partitions to help balance brokers.
+def build_num_partitions_on_broker_map(topic, all_broker_ids)
+  num_partitions_on_broker = Hash[all_broker_ids.collect { |id| [id, 0] }]
+  topic.partitions.each do |p|
+    p.replicas.each do |r|
+      num_partitions_on_broker[r] += 1
+    end
+  end
+  num_partitions_on_broker
+end

--- a/spec/factories/topic.rb
+++ b/spec/factories/topic.rb
@@ -36,17 +36,17 @@ module Kafkat
                      Partition.new(name, 4, [0, 1, 2], 1, 1)]}
       end
 
-      factory :skewed_topic do
-        partitions {[Partition.new(name, 0, [0, 1], 0, 0),
-                     Partition.new(name, 1, [], 1, 1)]}
-      end
-
       factory :topic_not_distributed_evenly do
         partitions {[Partition.new(name, 0, [0, 1], 0, 0),
                      Partition.new(name, 1, [0, 1], 1, 1),
                      Partition.new(name, 2, [0, 1], 1, 1),
                      Partition.new(name, 3, [0, 1], 0, 0),
                      Partition.new(name, 4, [0, 1], 1, 1)]}
+      end
+
+      factory :topic_not_distributed_evenly2 do
+        partitions {[Partition.new(name, 0, [0, 1], 0, 0),
+                     Partition.new(name, 1, [2, 3], 2, 2)]}
       end
     end
   end

--- a/spec/factories/topic.rb
+++ b/spec/factories/topic.rb
@@ -2,6 +2,7 @@ module Kafkat
   FactoryGirl.define do
     factory :topic, class:Topic do
       name "topic_name"
+      partitions Hash.new()
 
       factory :topic_with_one_empty_broker do
         partitions {[Partition.new(name, 0, [0], 0, 0),
@@ -33,6 +34,19 @@ module Kafkat
                      Partition.new(name, 2, [0, 1, 2], 2, 2),
                      Partition.new(name, 3, [0, 1, 2], 0, 0),
                      Partition.new(name, 4, [0, 1, 2], 1, 1)]}
+      end
+
+      factory :skewed_topic do
+        partitions {[Partition.new(name, 0, [0, 1], 0, 0),
+                     Partition.new(name, 1, [], 1, 1)]}
+      end
+
+      factory :topic_not_distributed_evenly do
+        partitions {[Partition.new(name, 0, [0, 1], 0, 0),
+                     Partition.new(name, 1, [0, 1], 1, 1),
+                     Partition.new(name, 2, [0, 1], 1, 1),
+                     Partition.new(name, 3, [0, 1], 0, 0),
+                     Partition.new(name, 4, [0, 1], 1, 1)]}
       end
     end
   end

--- a/spec/lib/kafkat/command/drain_spec.rb
+++ b/spec/lib/kafkat/command/drain_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Kafkat
-  RSpec.describe Command::Drain do
+  describe Command::Drain do
     let(:drain) { Command::Drain.new({}) }
     let(:broker_id) { 0 }
     let(:destination_broker_ids) { [1, 2] }

--- a/spec/lib/kafkat/command/reassign_spec.rb
+++ b/spec/lib/kafkat/command/reassign_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 module Kafkat
   RSpec.describe Command::Reassign do
-    let(:reassign) { Command::Reassign.new({}) }
+    let(:load_balanced_strategy) { Command::LoadBalancedStrategy.new() }
+    let(:smart_strategy) { Command::SmartStrategy.new() }
     let(:skewed_topic) { FactoryGirl.build(:skewed_topic) }
     let(:topic_not_distributed_evenly) { FactoryGirl.build(:topic_not_distributed_evenly) }
     let(:topic_rep_factor_one) { FactoryGirl.build(:topic_rep_factor_one) }
@@ -20,10 +21,12 @@ module Kafkat
 
     context 'strategy load-balanced' do
       it 'should evenly distribute replicas randomly' do
-        assignments = reassign.generate_assignment_load_balanced(
-          {"topic_name" => topic_rep_factor_two},
+        assignments = load_balanced_strategy.generate_topic_assignment(
+          topic_rep_factor_two,
+          2,
           [1, 2],
-          2)
+          [0, 1, 2],
+          3)
         expect(assignments).to have_exactly(5).Partitions
         assignments.each do |a|
           expect(a).to have_exactly(2).replicas
@@ -33,11 +36,12 @@ module Kafkat
 
     context 'default strategy smart' do
       it 'should evenly distribute replicas and minimize data movement' do
-        assignments = reassign.generate_assignment_smart(
-          {"topic_name" => topic_rep_factor_one},
-          [1, 2],
+        assignments = smart_strategy.generate_topic_assignment(
+          topic_rep_factor_one,
           1,
-          [0, 1, 2])
+          [1, 2],
+          [0, 1, 2],
+          3)
         expect(assignments).to have_exactly(5).Partitions
         expect([[1], [2]]).to include(assignments[0].replicas)
         expect(assignments[1].replicas).to eq([1])
@@ -47,11 +51,12 @@ module Kafkat
       end
 
       it 'should handle unevenly distribution properly' do
-        assignments = reassign.generate_assignment_smart(
-          {"topic_name" => topic_not_distributed_evenly},
-          [1, 2],
+        assignments = smart_strategy.generate_topic_assignment(
+          topic_not_distributed_evenly,
           1,
-          [0, 1, 2])
+          [1, 2],
+          [0, 1, 2],
+          3)
         expect(assignments).to have_exactly(5).Partitions
         expect(assignments[0].replicas).to eq([2])
         expect(assignments[1].replicas).to eq([2])
@@ -61,11 +66,12 @@ module Kafkat
       end
 
       it 'should handle more replications and brokers properly' do
-        assignments = reassign.generate_assignment_smart(
-          {"topic_name" => topic_rep_factor_one},
-          [0, 1, 2, 3],
+        assignments = smart_strategy.generate_topic_assignment(
+          topic_rep_factor_one,
           2,
-          [0, 1, 2, 3])
+          [0, 1, 2, 3],
+          [0, 1, 2, 3],
+          4)
         expect(assignments).to have_exactly(5).Partitions
         expect(assignments[0].replicas).to include(0)
         expect(assignments[1].replicas).to include(1)
@@ -78,11 +84,12 @@ module Kafkat
       end
 
       it 'should handle less replication and brokers properly' do
-        assignments = reassign.generate_assignment_smart(
-          {"topic_name" => topic_rep_factor_two},
-          [1, 2],
+        assignments = smart_strategy.generate_topic_assignment(
+          topic_rep_factor_two,
           1,
-          [0, 1, 2])
+          [1, 2],
+          [0, 1, 2],
+          3)
         expect(assignments).to have_exactly(5).Partitions
         expect(assignments[0].replicas).to eq([1])
         expect(assignments[1].replicas).to eq([2])
@@ -92,52 +99,15 @@ module Kafkat
       end
 
       it 'should handle skewed topic properly' do
-        assignments = reassign.generate_assignment_smart(
-          {"topic_name" => skewed_topic},
-          [0, 1],
+        assignments = smart_strategy.generate_topic_assignment(
+          skewed_topic,
           1,
-          [0, 1])
+          [0, 1],
+          [0, 1],
+          2)
         expect(assignments).to have_exactly(2).Partitions
         counts = count(assignments)
         expect(counts).to eq({0 => 1, 1 =>1})
-      end
-    end
-
-    context 'replication factor larger than destination broker size' do
-      it 'should fail' do
-        expect do
-          assignments = reassign.generate_assignment_load_balanced(
-            {"topic_name" => topic_rep_factor_two},
-            [1, 2],
-            3)
-        end.to raise_error(SystemExit)
-
-        expect do
-          assignments = reassign.generate_assignment_smart(
-            {"topic_name" => topic_rep_factor_two},
-            [1, 2],
-            3,
-            [0, 1, 2])
-        end.to raise_error(SystemExit)
-      end
-    end
-
-    context 'topic with no partiton' do
-      it 'should fail' do
-        expect do
-          assignments = reassign.generate_assignment_load_balanced(
-            {"topic_name" => FactoryGirl.build(:topic)},
-            [1, 2],
-            2)
-        end.to raise_error(SystemExit)
-
-        expect do
-          assignments = reassign.generate_assignment_smart(
-            {"topic_name" => FactoryGirl.build(:topic)},
-            [1, 2],
-            2,
-            [0, 1, 2])
-        end.to raise_error(SystemExit)
       end
     end
   end

--- a/spec/lib/kafkat/command/reassign_spec.rb
+++ b/spec/lib/kafkat/command/reassign_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 module Kafkat
   RSpec.describe Command::Reassign do
-    let(:load_balanced_strategy) { Command::LoadBalancedStrategy.new() }
-    let(:smart_strategy) { Command::SmartStrategy.new() }
-    let(:skewed_topic) { FactoryGirl.build(:skewed_topic) }
+    let(:load_balanced_strategy) { Command::LoadBalancedStrategy.new }
+    let(:smart_strategy) { Command::SmartStrategy.new }
     let(:topic_not_distributed_evenly) { FactoryGirl.build(:topic_not_distributed_evenly) }
+    let(:topic_not_distributed_evenly2) { FactoryGirl.build(:topic_not_distributed_evenly2) }
     let(:topic_rep_factor_one) { FactoryGirl.build(:topic_rep_factor_one) }
     let(:topic_rep_factor_two) { FactoryGirl.build(:topic_rep_factor_two) }
 
@@ -63,6 +63,16 @@ module Kafkat
         expect(assignments[2].replicas).to eq([1])
         expect(assignments[3].replicas).to eq([1])
         expect(assignments[4].replicas).to eq([1])
+
+        assignments2 = smart_strategy.generate_topic_assignment(
+          topic_not_distributed_evenly2,
+          1,
+          [0, 1],
+          [0, 1, 2, 3],
+          4)
+        expect(assignments2).to have_exactly(2).Partitions
+        expect(assignments2[0].replicas).to eq([1])
+        expect(assignments2[1].replicas).to eq([0])
       end
 
       it 'should handle more replications and brokers properly' do
@@ -96,18 +106,6 @@ module Kafkat
         expect([[1], [2]]).to include(assignments[2].replicas)
         expect(assignments[3].replicas).to eq([1])
         expect(assignments[4].replicas).to eq([2])
-      end
-
-      it 'should handle skewed topic properly' do
-        assignments = smart_strategy.generate_topic_assignment(
-          skewed_topic,
-          1,
-          [0, 1],
-          [0, 1],
-          2)
-        expect(assignments).to have_exactly(2).Partitions
-        counts = count(assignments)
-        expect(counts).to eq({0 => 1, 1 =>1})
       end
     end
   end

--- a/spec/lib/kafkat/command/reassign_spec.rb
+++ b/spec/lib/kafkat/command/reassign_spec.rb
@@ -1,0 +1,144 @@
+require 'spec_helper'
+
+module Kafkat
+  RSpec.describe Command::Reassign do
+    let(:reassign) { Command::Reassign.new({}) }
+    let(:skewed_topic) { FactoryGirl.build(:skewed_topic) }
+    let(:topic_not_distributed_evenly) { FactoryGirl.build(:topic_not_distributed_evenly) }
+    let(:topic_rep_factor_one) { FactoryGirl.build(:topic_rep_factor_one) }
+    let(:topic_rep_factor_two) { FactoryGirl.build(:topic_rep_factor_two) }
+
+    def count(assignments)
+      counts = Hash.new(0)
+      assignments.each do |a|
+        a.replicas.each do |id|
+          counts[id] += 1
+        end
+      end
+      counts
+    end
+
+    context 'strategy load-balanced' do
+      it 'should evenly distribute replicas randomly' do
+        assignments = reassign.generate_assignment_load_balanced(
+          {"topic_name" => topic_rep_factor_two},
+          [1, 2],
+          2)
+        expect(assignments).to have_exactly(5).Partitions
+        assignments.each do |a|
+          expect(a).to have_exactly(2).replicas
+        end
+      end
+    end
+
+    context 'default strategy smart' do
+      it 'should evenly distribute replicas and minimize data movement' do
+        assignments = reassign.generate_assignment_smart(
+          {"topic_name" => topic_rep_factor_one},
+          [1, 2],
+          1,
+          [0, 1, 2])
+        expect(assignments).to have_exactly(5).Partitions
+        expect([[1], [2]]).to include(assignments[0].replicas)
+        expect(assignments[1].replicas).to eq([1])
+        expect([[1], [2]]).to include(assignments[2].replicas)
+        expect(assignments[3].replicas).to eq([2])
+        expect(assignments[4].replicas).to eq([1])
+      end
+
+      it 'should handle unevenly distribution properly' do
+        assignments = reassign.generate_assignment_smart(
+          {"topic_name" => topic_not_distributed_evenly},
+          [1, 2],
+          1,
+          [0, 1, 2])
+        expect(assignments).to have_exactly(5).Partitions
+        expect(assignments[0].replicas).to eq([2])
+        expect(assignments[1].replicas).to eq([2])
+        expect(assignments[2].replicas).to eq([1])
+        expect(assignments[3].replicas).to eq([1])
+        expect(assignments[4].replicas).to eq([1])
+      end
+
+      it 'should handle more replications and brokers properly' do
+        assignments = reassign.generate_assignment_smart(
+          {"topic_name" => topic_rep_factor_one},
+          [0, 1, 2, 3],
+          2,
+          [0, 1, 2, 3])
+        expect(assignments).to have_exactly(5).Partitions
+        expect(assignments[0].replicas).to include(0)
+        expect(assignments[1].replicas).to include(1)
+        expect(assignments[2].replicas).to include(2)
+        expect(assignments[3].replicas).to include(0)
+        expect(assignments[4].replicas).to include(1)
+
+        counts = count(assignments)
+        expect(counts).to eq({0 => 3, 1 =>3, 2=>2, 3=>2})
+      end
+
+      it 'should handle less replication and brokers properly' do
+        assignments = reassign.generate_assignment_smart(
+          {"topic_name" => topic_rep_factor_two},
+          [1, 2],
+          1,
+          [0, 1, 2])
+        expect(assignments).to have_exactly(5).Partitions
+        expect(assignments[0].replicas).to eq([1])
+        expect(assignments[1].replicas).to eq([2])
+        expect([[1], [2]]).to include(assignments[2].replicas)
+        expect(assignments[3].replicas).to eq([1])
+        expect(assignments[4].replicas).to eq([2])
+      end
+
+      it 'should handle skewed topic properly' do
+        assignments = reassign.generate_assignment_smart(
+          {"topic_name" => skewed_topic},
+          [0, 1],
+          1,
+          [0, 1])
+        expect(assignments).to have_exactly(2).Partitions
+        counts = count(assignments)
+        expect(counts).to eq({0 => 1, 1 =>1})
+      end
+    end
+
+    context 'replication factor larger than destination broker size' do
+      it 'should fail' do
+        expect do
+          assignments = reassign.generate_assignment_load_balanced(
+            {"topic_name" => topic_rep_factor_two},
+            [1, 2],
+            3)
+        end.to raise_error(SystemExit)
+
+        expect do
+          assignments = reassign.generate_assignment_smart(
+            {"topic_name" => topic_rep_factor_two},
+            [1, 2],
+            3,
+            [0, 1, 2])
+        end.to raise_error(SystemExit)
+      end
+    end
+
+    context 'topic with no partiton' do
+      it 'should fail' do
+        expect do
+          assignments = reassign.generate_assignment_load_balanced(
+            {"topic_name" => FactoryGirl.build(:topic)},
+            [1, 2],
+            2)
+        end.to raise_error(SystemExit)
+
+        expect do
+          assignments = reassign.generate_assignment_smart(
+            {"topic_name" => FactoryGirl.build(:topic)},
+            [1, 2],
+            2,
+            [0, 1, 2])
+        end.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/lib/kafkat/command/reassign_spec.rb
+++ b/spec/lib/kafkat/command/reassign_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Kafkat
-  RSpec.describe Command::Reassign do
+  describe Command::Reassign do
     let(:load_balanced_strategy) { Command::LoadBalancedStrategy.new }
     let(:smart_strategy) { Command::SmartStrategy.new }
     let(:topic_not_distributed_evenly) { FactoryGirl.build(:topic_not_distributed_evenly) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ if ENV['COVERAGE']
 end
 require 'kafkat'
 require 'factory_girl'
+require 'pry'
 require 'rspec/collection_matchers'
 
 require_relative '../spec/factories/topic'


### PR DESCRIPTION
to: @alexism 

Previously when we reassign partitions, all replicas are assigned
randomly assigned brokers, given some brokers already have some
partitions on it.

In this commit, I added a `--strategy` option to `reassign` command,
which default to reduce data movement by choose to assign replicas
to those brokers already have them on. The previous behavior is
preserved under `load-balanced` strategy.

To make the "smart" reassignment happen, two requirements need to
be met:
1. replicas should be evenly distributed among brokers;
2. replicas moving around should be avoided as possible.
Given that both the replication factor and destination brokers
are changable through user input, this is actually algorithmly
very challenging. The detail are described under relevent files.

Tests are also added to cover `reassign` command in general,
except for the IO part, which can be easily verified.
