### PR TITLE
fix tab count in formatting

### DIFF
--- a/lib/kafkat/utility/formatting.rb
+++ b/lib/kafkat/utility/formatting.rb
@@ -2,7 +2,7 @@ module Kafkat
   module Formatting
     def justify(field, width=2)
       field = field.to_s
-      count = [width - (field.length / 8), 0].max
+      count = [width - (field.length / 8), 1].max
       field + "\t" * count
     end
 


### PR DESCRIPTION
Found a bug with the tab counts between fields (Especially for partition numbers) whenever the name of the topic is too long. Added a fix so that there is at least one tab space in the formatted output between fields.

The following illustrates the problem:

``` bash
# Without tab count fix
~$ kafkat partitions appointment_engine
Topic       Partition   Leader      Replicas                        ISRs
appointment_engine0     4       [4, 7, 10]                      [4, 10, 7]
appointment_engine1     6       [6, 9, 10]                      [6, 9, 10]
appointment_engine2     6       [6, 4, 5]                       [5, 6, 4]
appointment_engine3     8       [8, 0, 1]                       [8, 0, 1]
appointment_engine4     9       [9, 1, 2]                       [2, 9, 1]
appointment_engine5     10      [10, 2, 3]                      [2, 10, 3]
appointment_engine6     0       [0, 3, 4]                       [4, 0, 3]
appointment_engine7     1       [1, 4, 5]                       [4, 5, 1]
appointment_engine8     2       [2, 5, 6]                       [2, 5, 6]
appointment_engine9     3       [3, 6, 7]                       [6, 3, 7]
appointment_engine10        4       [4, 7, 8]                       [4, 8, 7]
appointment_engine11        5       [5, 4, 10]                      [4, 5, 10]
appointment_engine12        6       [6, 10, 0]                      [6, 0, 10]
appointment_engine13        7       [7, 0, 1]                       [0, 1, 7]
appointment_engine14        2       [2, 8, 5]                       [2, 5, 8]
appointment_engine15        9       [9, 2, 3]                       [2, 9, 3]
appointment_engine16        10      [10, 3, 4]                      [4, 10, 3]
appointment_engine17        0       [0, 4, 5]                       [4, 5, 0]
appointment_engine18        1       [1, 5, 6]                       [5, 6, 1]
appointment_engine19        2       [2, 6, 7]                       [2, 6, 7]
appointment_engine20        3       [3, 7, 8]                       [8, 3, 7]
appointment_engine21        4       [4, 8, 9]                       [4, 9, 8]
appointment_engine22        6       [6, 5, 10]                      [5, 6, 10]
appointment_engine23        6       [6, 0, 1]                       [6, 0, 1]
appointment_engine24        7       [7, 1, 2]                       [2, 1, 7]
# It can be seen that there is no tab space between topic name and partition number.

## After fix
 ~$ bin/kafkat partitions appointment_engine
Topic       Partition   Leader      Replicas                        ISRs
appointment_engine  0       4       [4, 7, 10]                      [4, 10, 7]
appointment_engine  1       6       [6, 9, 10]                      [6, 9, 10]
appointment_engine  2       6       [6, 4, 5]                       [5, 6, 4]
appointment_engine  3       8       [8, 0, 1]                       [8, 0, 1]
appointment_engine  4       9       [9, 1, 2]                       [2, 9, 1]
appointment_engine  5       10      [10, 2, 3]                      [2, 10, 3]
appointment_engine  6       0       [0, 3, 4]                       [4, 0, 3]
appointment_engine  7       1       [1, 4, 5]                       [4, 5, 1]
appointment_engine  8       2       [2, 5, 6]                       [2, 5, 6]
appointment_engine  9       3       [3, 6, 7]                       [6, 3, 7]
appointment_engine  10      4       [4, 7, 8]                       [4, 8, 7]
appointment_engine  11      5       [5, 4, 10]                      [4, 5, 10]
appointment_engine  12      6       [6, 10, 0]                      [6, 0, 10]
appointment_engine  13      7       [7, 0, 1]                       [0, 1, 7]
appointment_engine  14      2       [2, 8, 5]                       [2, 5, 8]
appointment_engine  15      9       [9, 2, 3]                       [2, 9, 3]
appointment_engine  16      10      [10, 3, 4]                      [4, 10, 3]
appointment_engine  17      0       [0, 4, 5]                       [4, 5, 0]
appointment_engine  18      1       [1, 5, 6]                       [5, 6, 1]
appointment_engine  19      2       [2, 6, 7]                       [2, 6, 7]
appointment_engine  20      3       [3, 7, 8]                       [8, 3, 7]
appointment_engine  21      4       [4, 8, 9]                       [4, 9, 8]
appointment_engine  22      6       [6, 5, 10]                      [5, 6, 10]
appointment_engine  23      6       [6, 0, 1]                       [6, 0, 1]
appointment_engine  24      7       [7, 1, 2]                       [2, 1, 7]

# At least one tab space is present between topic and partition
```
