### PR TITLE
Add configs option to print the version and config by topic.

### DIFF
--- a/lib/kafkat/command/configs.rb
+++ b/lib/kafkat/command/configs.rb
@@ -1,0 +1,21 @@
+module Kafkat
+  module Command
+    class Configs < Base
+      register_as 'configs'
+
+      usage 'configs [topic]',
+            'Print the version and config by topic.'
+
+      def run
+        topic_name = ARGV.shift
+        topic_names = topic_name && [topic_name]
+        topics = zookeeper.get_topics(topic_names)
+
+        print_config_header
+        topics.each do |name, t|
+          print_config(name, zookeeper.get_config(name))
+        end
+      end
+    end
+  end
+end

--- a/lib/kafkat/utility/formatting.rb
+++ b/lib/kafkat/utility/formatting.rb
@@ -18,6 +18,18 @@ module Kafkat
       print "\n"
     end
 
+    def print_config(topic_name, config)
+      print justify(topic_name)
+      print justify(config)
+      print "\n"
+    end
+
+    def print_config_header
+      print justify('Topic')
+      print justify('Config')
+      print "\n"
+    end
+
     def print_topic(topic)
       print justify(topic.name)
       print "\n"


### PR DESCRIPTION
Add an option to display the per-topic configuration information (http://kafka.apache.org/081/documentation.html#topic-config).

```
% kafkat
kafkat 0.0.13: Simplified command-line administration for Kafka brokers
usage: kafkat [command] [options]

Here's a list of supported commands:

....
  configs [topic]                                                     Print the version and config by topic.
....
```

```
% kafkat configs
Topic       Config
test1       {"version"=>1, "config"=>{}}
test2       {"version"=>1, "config"=>{"retention.ms"=>"12096000000"}}
test3       {"version"=>1, "config"=>{"segment.index.bytes"=>"10485760", "segment.bytes"=>"1073741824", "flush.ms"=>"1000", "delete.retention.ms"=>"86400000", "retention.bytes"=>"1024", "index.interval.bytes"=>"4096", "cleanup.policy"=>"delete", "segment.ms"=>"12096000000", "max.message.bytes"=>"1000000", "flush.messages"=>"1", "min.cleanable.dirty.ratio"=>"0.5", "retention.ms"=>"12096000000"}}
```
