### PR TITLE
Add configs command and ThreadError handling

### DIFF
--- a/lib/kafkat/command/configs.rb
+++ b/lib/kafkat/command/configs.rb
@@ -1,0 +1,21 @@
+module Kafkat
+  module Command
+    class Configs < Base
+      register_as 'configs'
+
+      usage 'configs [topic]',
+            'Print the version and config by topic.'
+
+      def run
+        topic_name = ARGV.shift
+        topic_names = topic_name && [topic_name]
+
+        configs = zookeeper.get_configs(topic_names)
+        print_config_header
+        configs.each do |name, c|
+          print_config(name, c)
+        end
+      end
+    end
+  end
+end

--- a/lib/kafkat/utility/formatting.rb
+++ b/lib/kafkat/utility/formatting.rb
@@ -18,6 +18,18 @@ module Kafkat
       print "\n"
     end
 
+    def print_config(topic_name, config)
+      print justify(topic_name)
+      print justify(config)
+      print "\n"
+    end
+
+    def print_config_header
+      print justify('Topic')
+      print justify('Config')
+      print "\n"
+    end
+
     def print_topic(topic)
       print justify(topic.name)
       print "\n"


### PR DESCRIPTION
Add an option to display the per-topic configuration information by topic (http://kafka.apache.org/081/documentation.html#topic-config).

I noticed that when running commands such as `kafkat topics` on a cluster with many topics, incomplete results were being received on my mac, but not on linux hosts.  I believe this is due to a thread limit on macs.  I included a commit to raise an exception in this case to avoid incorrect results.

New configs command:

```
% kafkat
kafkat 0.0.13: Simplified command-line administration for Kafka brokers
usage: kafkat [command] [options]

Here's a list of supported commands:

....
  configs [topic]                                                     Print the version and config by topic.
....
```

```
% kafkat configs
Topic           Config
test1           {"version"=>1, "config"=>{}}
test2           {"version"=>1, "config"=>{"retention.ms"=>"12096000000"}}
test3           {"version"=>1, "config"=>{"segment.index.bytes"=>"10485760", "segment.bytes"=>"1073741824", "flush.ms"=>"1000", "delete.retention.ms"=>"86400000", "retention.bytes"=>"1024", "index.interval.bytes"=>"4096", "cleanup.policy"=>"delete", "segment.ms"=>"12096000000", "max.message.bytes"=>"1000000", "flush.messages"=>"1", "min.cleanable.dirty.ratio"=>"0.5", "retention.ms"=>"12096000000"}}
```

Sample ThreadError exception on a mac:

```
% bin/kafkat topics
The allowed number of threads might have been exceeded, current number of threads is 2047.
....
warning repeats for many Thread.new attempts....
....
The allowed number of threads might have been exceeded, current number of threads is 2047./Users/chaferd/dev/kafkat/lib/kafkat/interface/zookeeper.rb:108:in `initialize': can't create Thread: Resource temporarily unavailable (ThreadError)
    from /Users/chaferd/dev/kafkat/lib/kafkat/interface/zookeeper.rb:108:in `new'
    from /Users/chaferd/dev/kafkat/lib/kafkat/interface/zookeeper.rb:108:in `block in get_topic'
    from /Users/chaferd/dev/kafkat/lib/kafkat/interface/zookeeper.rb:106:in `map'
    from /Users/chaferd/dev/kafkat/lib/kafkat/interface/zookeeper.rb:106:in `get_topic'
    from /Users/chaferd/dev/kafkat/lib/kafkat/interface/zookeeper.rb:86:in `block (2 levels) in get_topics'
```
