### PR TITLE
Add CLI interface for Kafka Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ kafkat
 
 Simplified command-line administration for Kafka brokers.
 
-## Contact 
+## Contact
 **Let us know!** If you fork this, or if you use it, or if it helps in anyway, we'd love to hear from you! opensource@airbnb.com
 
 ## License & Attributions
@@ -44,6 +44,9 @@ Here's a list of supported commands:
   brokers                                                             Print available brokers from Zookeeper.
   clean-indexes                                                       Delete untruncated Kafka log indexes from the filesystem.
   controller                                                          Print the current controller.
+  connectors [connector-name]                                         View configured connectors
+  connectors <connector-name> --configure [--config] [--config-file]  Configure connector with specified id
+  connectors <connector-name> --delete                                Delete connector with specified id
   elect-leaders [topic]                                               Begin election of the preferred leaders.
   partitions [topic]                                                  Print partitions by topic.
   partitions [topic] --under-replicated                               Print partitions by topic (only under-replicated).
@@ -55,7 +58,7 @@ Here's a list of supported commands:
   shutdown <broker id>                                                Gracefully remove leaderships from a broker (requires JMX).
   topics                                                              Print all topics.
   drain <broker id> [--topic <t>] [--brokers <ids>]                   Reassign partitions from a specific broker to other brokers.
-  
+
 ```
 
 ## Important Note

--- a/kafkat.gemspec
+++ b/kafkat.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'highline', '~> 1.6', '>= 1.6.21'
   s.add_runtime_dependency 'retryable', '~> 1.3', '>= 1.3.5'
   s.add_runtime_dependency 'colored', '~> 1.2'
+  s.add_runtime_dependency 'rest-client', '~> 2.0.0'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'simplecov'

--- a/lib/kafkat/command.rb
+++ b/lib/kafkat/command.rb
@@ -60,6 +60,12 @@ module Kafkat
           Interface::KafkaLogs.new(config)
         end
       end
+
+      def connect
+        @connect ||= begin
+          Interface::Connect.new(config)
+        end
+      end
     end
   end
 end

--- a/lib/kafkat/command/connectors.rb
+++ b/lib/kafkat/command/connectors.rb
@@ -1,0 +1,89 @@
+module Kafkat
+  module Command
+    class Connectors < Base
+      register_as 'connectors'
+
+      usage 'connectors [connector-name]',
+            'View configured connectors'
+      usage 'connectors <connector-name> --configure [--config] [--config-file]',
+            'Configure connector with specified id'
+      usage 'connectors <connector-name> --delete',
+            'Delete connector with specified id'
+
+      def run
+        @connector_name = ARGV.shift unless ARGV[0] && ARGV[0].start_with?('--')
+
+        if !@connector_name
+          list
+          exit
+        end
+
+        @options = Trollop.options do
+          opt :configure, "create new connector"
+          opt :config, "connector config in JSON format", type: :string
+          opt :config_file, "path to file containing connector config in JSON format", type: :string
+          opt :remove, "remove connector"
+        end
+
+        if @options.configure
+          configure
+        elsif @options.remove
+          remove
+        else
+          show
+        end
+      end
+
+      def list
+        connectors = connect.list
+        if connectors.empty?
+          puts 'No connectors configured, add one by running connectors --create'
+        else
+          puts "#{connectors.length} connector(s) configured:"
+          connectors.each do |connector|
+            puts connector
+          end
+        end
+      end
+
+      def show
+        connector = connect.show(@connector_name)
+        if connector
+          puts JSON.pretty_generate(connector)
+        else
+          puts "Connector '#{@connector_name}' not found"
+        end
+      end
+
+      def configure
+        unless @options.config || @options.config_file
+          puts "Please specify the connector JSON configuration using --config or --config-file"
+          exit 1
+        end
+
+        if @options.config_file
+          config = File.read(@options.config_file)
+        else
+          config = @options.config
+        end
+
+        puts "Configuring '#{@connector_name}' with:"
+        puts config
+        return unless agree("Proceed (y/n)?")
+
+        connect.configure(@connector_name, config)
+
+        puts "Connector '#{@connector_name}' configured"
+      end
+
+      def remove
+        puts "Removing '#{@connector_name}'"
+        return unless agree("Proceed (y/n)?")
+
+        connect.remove(@connector_name)
+
+        puts "Connector '#{@connector_name}' removed"
+      end
+    end
+  end
+end

--- a/lib/kafkat/config.rb
+++ b/lib/kafkat/config.rb
@@ -11,6 +11,7 @@ module Kafkat
     attr_reader :kafka_path
     attr_reader :log_path
     attr_reader :zk_path
+    attr_reader :connect_api_host
 
     def self.load!
       string = nil
@@ -40,6 +41,7 @@ module Kafkat
       @kafka_path = json['kafka_path']
       @log_path = json['log_path']
       @zk_path = json['zk_path']
+      @connect_api_host = json['connect_api_host']
     end
   end
 end

--- a/lib/kafkat/interface.rb
+++ b/lib/kafkat/interface.rb
@@ -1,3 +1,4 @@
 require 'kafkat/interface/admin'
+require 'kafkat/interface/connect'
 require 'kafkat/interface/kafka_logs'
 require 'kafkat/interface/zookeeper'

--- a/lib/kafkat/interface/connect.rb
+++ b/lib/kafkat/interface/connect.rb
@@ -1,0 +1,42 @@
+require 'json'
+require 'rest-client'
+
+module Kafkat
+  module Interface
+    class Connect
+      attr_reader :connect_api_host
+
+      def initialize(config)
+        @connect_api_host = config.connect_api_host || 'http://localhost:8083'
+      end
+
+      def list
+        JSON.parse(RestClient.get(api_path('/connectors'), api_options))
+      end
+
+      def show(connector)
+        JSON.parse(RestClient.get(api_path("/connectors/#{connector}"), api_options))
+      rescue RestClient::NotFound
+        nil
+      end
+
+      def configure(connector, config)
+        RestClient.put(api_path("/connectors/#{connector}/config"), config, api_options)
+      end
+
+      def remove(connector)
+        RestClient.delete(api_path("/connectors/#{connector}"), api_options)
+      end
+
+      protected
+
+      def api_path(path)
+        "#{connect_api_host}#{path}"
+      end
+
+      def api_options
+        {:content_type => :json, :accept => :json}
+      end
+    end
+  end
+end


### PR DESCRIPTION
We're experimenting with the new Kafka feature Connect and need a simple CLI tool to manage the configuration. This seems like a nice addition to this tool. Let me know if you think it's a good fit!

Kafka Connect is configured via a Rest api: http://docs.confluent.io/3.0.0/connect/userguide.html#rest-interface. This commit adds a simple wrapper around this API for easier management.
