### PR TITLE
Allow for ragged partition sizes when enforcing the replication factor

### DIFF
--- a/kafkat.gemspec
+++ b/kafkat.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "activesupport", ">= 2", "< 5"
   s.add_development_dependency 'rake'
   s.add_development_dependency 'simplecov', '~> 0.11.0'
-  s.add_development_dependency 'rspec', '~> 3.2.0'
+  s.add_development_dependency 'rspec', '~> 3.5.0'
   s.add_development_dependency 'rspec-collection_matchers', '~> 1.1.0'
   s.add_development_dependency 'factory_girl', '~> 4.5.0'
 end


### PR DESCRIPTION
The old code assumed all partitioned were equally sized, sometimes, that can not be the case. This calculates the assignments on a per-partition basis.