### PR TITLE
Add the optimist gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 Gemfile.lock
 reports
 .rakeTasks
+vendor

--- a/kafkat.gemspec
+++ b/kafkat.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_runtime_dependency 'zk', '~> 1.9', '>= 1.9.4'
-  s.add_runtime_dependency 'trollop', '~> 2.0'
+  s.add_runtime_dependency 'optimist', '~> 3.0'
   s.add_runtime_dependency 'highline', '~> 1.6', '>= 1.6.21'
   s.add_runtime_dependency 'retryable', '~> 1.3', '>= 1.3.5'
   s.add_runtime_dependency 'colored', '~> 1.2'
   s.add_runtime_dependency 'json', '~> 1.8'
 
-  s.add_development_dependency "activesupport", ">= 2", "< 5"
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'activesupport', '>= 2', '< 5'
+  s.add_development_dependency 'rake', '<= 10.5.0'
   s.add_development_dependency 'simplecov', '~> 0.11.0'
   s.add_development_dependency 'rspec', '~> 3.2.0'
   s.add_development_dependency 'rspec-collection_matchers', '~> 1.1.0'

--- a/lib/kafkat.rb
+++ b/lib/kafkat.rb
@@ -1,6 +1,6 @@
 require 'zk'
 require 'json'
-require 'trollop'
+require 'optimist'
 require 'retryable'
 require 'highline/import'
 require 'colored'

--- a/lib/kafkat/command/drain.rb
+++ b/lib/kafkat/command/drain.rb
@@ -24,7 +24,7 @@ module Kafkat
           exit 1
         end
 
-        opts = Trollop.options do
+        opts = Optimist.options do
           opt :brokers, "destination broker IDs", type: :string
           opt :topic,   "topic name to reassign", type: :string
         end

--- a/lib/kafkat/command/partitions.rb
+++ b/lib/kafkat/command/partitions.rb
@@ -14,7 +14,7 @@ module Kafkat
         topic_name = ARGV.shift unless ARGV[0] && ARGV[0].start_with?('--')
         topic_names = topic_name && [topic_name]
 
-        @options = Trollop.options do
+        @options = Optimist.options do
           opt :under_replicated, "only under-replicated"
           opt :unavailable, "only unavailable"
         end

--- a/lib/kafkat/command/reassign.rb
+++ b/lib/kafkat/command/reassign.rb
@@ -18,7 +18,7 @@ module Kafkat
         end
         topics ||= zookeeper.get_topics
 
-        opts = Trollop.options do
+        opts = Optimist.options do
           opt :brokers, "replica set (broker IDs)", type: :string
           opt :replicas, "number of replicas (count)", type: :integer
         end

--- a/lib/kafkat/command/resign-rewrite.rb
+++ b/lib/kafkat/command/resign-rewrite.rb
@@ -16,7 +16,7 @@ module Kafkat
           exit 1
         end
 
-        opts = Trollop.options do
+        opts = Optimist.options do
           opt :force, "force"
         end
 

--- a/lib/kafkat/command/set-replication-factor.rb
+++ b/lib/kafkat/command/set-replication-factor.rb
@@ -29,7 +29,7 @@ module Kafkat
         topics = topic_name && zookeeper.get_topics([topic_name])
         topics ||= zookeeper.get_topics
 
-        opts = Trollop.options do
+        opts = Optimist.options do
           opt :brokers, "the comma-separated list of broker the new partitions must be assigned to", type: :string
           opt :newrf, "the new replication factor", type: :integer, required: true
         end

--- a/lib/kafkat/command/verify-replicas.rb
+++ b/lib/kafkat/command/verify-replicas.rb
@@ -7,7 +7,7 @@ module Kafkat
             'Check if all partitions in a topic have same number of replicas.'
 
       def run
-        opts = Trollop.options do
+        opts = Optimist.options do
           opt :topics, "topic names", type: :string
           opt :broker, "broker ID", type: :string
           opt :print_details, "show replica size of mismatched partitions", :default => false


### PR DESCRIPTION
This commit addresses the following items:

* The trollop gem was renamed August 24th, 2018 to optimist due to it's offensive nature (see https://github.com/ManageIQ/optimist/issues/92).  This commit fixes issue #34 by replacing trollop with optimist.  The rename did not change functionality.
* Rake is also pinned to 10.5.0 to fix an incompatibility where the `last_comment` method was deprecated in ~>11.0 and removed from rake in ~>12.0, but still required by rspec-core.
* The vendor directory was also added to gitignore as the standard path for vendoring with bundler.